### PR TITLE
Changes polls response to return date instead of dates

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -33,7 +33,7 @@ app.get('/polls', cache('12 hours'), (req, res) => {
         }).get()]
       }).get()
   })
-  .then(table => table.map(([institute, M, L, C, KD, S, V, MP, SD, FI, Ö, dates]) => ({institute, dates, parties: {M, L, C, KD, S, V, MP, SD, FI, Ö}})))
+  .then(table => table.map(([institute, M, L, C, KD, S, V, MP, SD, FI, Ö, date]) => ({institute, date, parties: {M, L, C, KD, S, V, MP, SD, FI, Ö}})))
   .then(institutes => res.json(institutes))
   .catch(err => res.status(500).json(err))
 })


### PR DESCRIPTION
The response from `/polls` now returns `date` (as expected from the client) instead of `dates`, see #8 

Closes #8 