### PR TITLE
Fix layout of polls

### DIFF
--- a/src/components/Polls.css
+++ b/src/components/Polls.css
@@ -1,32 +1,31 @@
 .App-polls {
-  max-width: 100%;
-  overflow-x: auto;
+  display: grid;
+  grid-template-columns: 20px 1fr minmax(auto, 960px) 1fr 20px;
+  justify-content: center;
+  margin-bottom: 16px;
 }
 
 .App-polls span {
-  display: flex;
-  flex-direction: row;
-  margin-left: auto;
-  margin-right: auto;
-  max-width: 600px;
-}
-
-.App-polls .poll {
-  flex: 1;
+  display: grid;
+  gap: 20px;
+  grid-column: 3/4;
+  grid-template-columns: repeat(auto-fit, minmax(100px, max-content));
+  justify-content: center;
 }
 
 .App-polls .poll button {
-  display: inline-table;
-  text-align: center;
-  border: 1px solid white;
-  background: white;
+  background: #fff;
   border-radius: 5px;
+  border: 1px solid #fff;
+  display: block;
   height: 4em;
-  min-width: 7em;
+  padding: 0;
+  text-align: center;
+  width: 100%;
 }
 
 .App-polls .poll small {
-  display: inline-table;
   text-align: center;
   font-size: 8px;
 }
+


### PR DESCRIPTION
The layout of the polls looks broken. This PR fixes that with the help of some CSS grid magic.

| Before | After |
| ------ | ----- |
| <img width="1012" alt="Skärmavbild 2021-06-03 kl  20 04 17" src="https://user-images.githubusercontent.com/1478102/120691634-ff31c880-c4a6-11eb-893b-09071178eddd.png"> | <img width="1044" alt="Skärmavbild 2021-06-03 kl  20 02 57" src="https://user-images.githubusercontent.com/1478102/120691644-00fb8c00-c4a7-11eb-8e43-1ed3cd90e080.png"> |
| <img width="427" alt="Skärmavbild 2021-06-03 kl  20 07 21" src="https://user-images.githubusercontent.com/1478102/120692030-83844b80-c4a7-11eb-927f-cbbd62363766.png"> | <img width="425" alt="Skärmavbild 2021-06-03 kl  20 08 22" src="https://user-images.githubusercontent.com/1478102/120692032-84b57880-c4a7-11eb-99f3-12574316b430.png"> |



 
